### PR TITLE
Clarified Legacy PXE mode, changed NUC hostnames, changed preseed con…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ The jinja2 input data file `bootptab.json` needs to look like this for things to
 ```json
 {
     "mac": {
-        "mintnuc1": "aa:bb:00:cc:11:dd",
-        "mintnuc2": "dd:11:cc:00:bb:aa",
-        "mintnuc3": "aa:00:bb:11:cc:dd",
-        "mintnuc4": "00:bb:aa:dd:11:cc"
+        "nuc1": "aa:bb:00:cc:11:dd",
+        "nuc2": "dd:11:cc:00:bb:aa",
+        "nuc3": "aa:00:bb:11:cc:dd",
+        "nuc4": "00:bb:aa:dd:11:cc"
     }
 }
 ```
@@ -68,10 +68,10 @@ wakenuc <nuc_index_number>
 Configure your workstation's `/etc/hosts` file by adding the following entries:
 
 ```text
-192.168.2.101   mintnuc1
-192.168.2.102   mintnuc2
-192.168.2.103   mintnuc3
-192.168.2.104   mintnuc4
+192.168.2.101   nuc1
+192.168.2.102   nuc2
+192.168.2.103   nuc3
+192.168.2.104   nuc4
 ```
 
 ## Intel NUC Ubuntu 18.04 LTS installation
@@ -125,8 +125,8 @@ ansible-playbook -i inventory nucs.yml --extra-vars "nuc_user=$(whoami)" --ask-b
   mkdir -p $HOME/.dsh/group
   cp host/config/dsh.conf $HOME/.dsh
   touch $HOME/.dsh/machines.list
-  for i in $(seq 1 4); do echo "mintnuc$i" >> $HOME/.dsh/machines.list; done
+  for i in $(seq 1 4); do echo "nuc$i" >> $HOME/.dsh/machines.list; done
   ln -sf ../machines.list $HOME/.dsh/group/all
-  echo "mintnuc1" >> $HOME/.dsh/group/nucs.master
-  for i in $(seq 2 4); do echo "mintnuc$i" >> $HOME/.dsh/group/nucs.worker; done
+  echo "nuc1" >> $HOME/.dsh/group/nuc.master
+  for i in $(seq 2 4); do echo "nuc$i" >> $HOME/.dsh/group/nuc.worker; done
   ```

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,10 +1,10 @@
 # main inventory
 
 # group_vars/nucs
-# host_vars/mintnuc[1:4]
+# host_vars/nuc[1:4]
 
 all:
   children:
     nucs:
       hosts:
-        mintnuc[1:4]:
+        nuc[1:4]:

--- a/host/config/bootptab.j2
+++ b/host/config/bootptab.j2
@@ -2,7 +2,7 @@
 # machine entries have the following format:
 #
 # hostname      hwtype  hwaddr              ipaddr          bootfile
-mintnuc1        1       {{ mac.mintnuc1 }}  192.168.2.101
-mintnuc2        1       {{ mac.mintnuc2 }}  192.168.2.102
-mintnuc3        1       {{ mac.mintnuc3 }}  192.168.2.103
-mintnuc4        1       {{ mac.mintnuc4 }}  192.168.2.104
+nuc1            1       {{ mac.nuc1 }}      192.168.2.101
+nuc2            1       {{ mac.nuc2 }}      192.168.2.102
+nuc3            1       {{ mac.nuc3 }}      192.168.2.103
+nuc4            1       {{ mac.nuc4 }}      192.168.2.104

--- a/host/config/ssh_config
+++ b/host/config/ssh_config
@@ -6,23 +6,23 @@ Host *
   ServerAliveInterval 30
   ServerAliveCountMax 5
   TCPKeepAlive yes
-Host mintnuc1
+Host nuc1
   HostName 192.168.2.101
-  User haubenr
+  User johndoe
   Port 22
   LocalCommand ssh-colorizer "red"
-Host mintnuc2
+Host nuc2
   HostName 192.168.2.102
-  User haubenr
+  User johndoe
   Port 22
   LocalCommand ssh-colorizer "green"
-Host mintnuc3
+Host nuc3
   HostName 192.168.2.103
-  User haubenr
+  User johndoe
   Port 22
   LocalCommand ssh-colorizer "blue"
-Host mintnuc4
+Host nuc4
   HostName 192.168.2.104
-  User haubenr
+  User johndoe
   Port 22
   LocalCommand ssh-colorizer "yellow"

--- a/host/config/tmuxinator.yml
+++ b/host/config/tmuxinator.yml
@@ -44,7 +44,7 @@ windows:
       layout: tiled
       synchronize: after
       panes:
-        - ssh mintnuc1
-        - ssh mintnuc2
-        - ssh mintnuc3
-        - ssh mintnuc4
+        - ssh nuc1
+        - ssh nuc2
+        - ssh nuc3
+        - ssh nuc4

--- a/host/pxe_server/preseed-ubuntu-18.04-server-amd64.cfg.j2
+++ b/host/pxe_server/preseed-ubuntu-18.04-server-amd64.cfg.j2
@@ -8,8 +8,15 @@ d-i debconf/priority select critical
 d-i debian-installer/language string en
 d-i debian-installer/country string DE
 d-i debian-installer/locale string en_US.UTF-8
+d-i localechooser/supported-locales multiselect en_US.UTF-8
+d-i pkgsel/install-language-support boolean true
 d-i console-setup/ask_detect boolean false
+d-i console-setup/layoutcode string de
+d-i keyboard-configuration/modelcode string pc105
+d-i keyboard-configuration/layoutcode string de
+d-i keyboard-configuration/variantcode string nodeadkeys
 d-i keyboard-configuration/xkb-keymap select de(nodeadkeys)
+d-i debconf/language string en_US:en
 
 ### Network configuration
 d-i netcfg/choose_interface select auto
@@ -34,46 +41,16 @@ d-i clock-setup/ntp boolean true
 ### Partitioning
 d-i partman-auto/disk string /dev/nvme0n1
 d-i partman-auto/method string lvm
+d-i partman-auto/cap-ram {{ ram_size }}
 d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
 d-i partman-lvm/confirm boolean true
 d-i partman-lvm/confirm_nooverwrite boolean true
-
-# Physical partitions:
-# 1. BIOS boot partition: 1 MB
-# 2. Boot partition: 250 MB
-# 2. LVM, with the following logical volumes
-#     - Swap: 100% of RAM
-#     - Root partition: rest of space, ext4
-d-i partman-auto/expert_recipe string                         \
-      boot-root ::                                            \
-              1 1 1 free method{ biosgrub } .                 \
-              250 250 250 ext2                                \
-                      $primary{ } $bootable{ }                \
-                      method{ format } format{ }              \
-                      use_filesystem{ } filesystem{ ext2 }    \
-                      mountpoint{ /boot }                     \
-              .                                               \
-              100% 2048 100% linux-swap                       \
-                      lv_name{ swap }                         \
-                      method{ swap } format{ }                \
-                      $lvmok{ }                               \
-              .                                               \
-              256000 256000 256000 ext4                       \
-                      lv_name{ root }                         \
-                      method{ lvm } format{ }                 \
-                      use_filesystem{ } filesystem{ ext4 }    \
-                      mountpoint{ / }                         \
-                      $lvmok{ }                               \
-              .                                               \
-              1024 1024 -1 xfs                                \
-                      lv_name{ data }                         \
-                      method{ lvm } format{ }                 \
-                      use_filesystem{ } filesystem{ xfs }     \
-                      mountpoint{ /data }                     \
-                      $lvmok{ }                               \
-              .
+d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman-basicfilesystems/no_swap boolean false
+d-i partman-auto-lvm/guided_size string max
 d-i partman-auto/choose_recipe select atomic
-d-i partman/default_filesystem string ext4
+d-i partman-auto-lvm/new_vg_name string system-vg
 d-i partman-partitioning/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
@@ -108,7 +85,8 @@ d-i debian-installer/splash boolean false
 d-i grub-installer/bootdev string /dev/nvme0n1
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
-d-i	grub-installer/timeout string 5
+d-i	grub-installer/timeout string 0
+d-i debian-installer/add-kernel-opts string vga=789 nomodeset
 
 ### Finishing up the installation
 d-i finish-install/reboot_in_progress note

--- a/host/pxe_server/preseed-ubuntu-18.04-server-amd64.cfg.j2
+++ b/host/pxe_server/preseed-ubuntu-18.04-server-amd64.cfg.j2
@@ -50,6 +50,7 @@ d-i partman-auto/purge_lvm_from_device boolean true
 d-i partman-basicfilesystems/no_swap boolean false
 d-i partman-auto-lvm/guided_size string max
 d-i partman-auto/choose_recipe select atomic
+d-i partman/default_filesystem string ext4
 d-i partman-auto-lvm/new_vg_name string system-vg
 d-i partman-partitioning/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish

--- a/host/pxe_server/preseed-ubuntu-18.04-server-amd64.cfg.j2
+++ b/host/pxe_server/preseed-ubuntu-18.04-server-amd64.cfg.j2
@@ -98,7 +98,11 @@ d-i finish-install/reboot_in_progress note
 d-i preseed/early_command string kill-all-dhcp; netcfg
 d-i preseed/late_command string in-target mkdir /home/{{ user.login }}/.ssh; \
                                 in-target sh -c 'echo "{{ user.ssh_pub_key }}" >> /home/{{ user.login }}/.ssh/authorized_keys'; \
-                                in-target chown -R {{ user.login }}:{{ user.login }} /home/{{ user.login }}/.ssh;
-                                #in-target sh -c 'echo "{{ user.login }} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/rc' ; \
-                                #in-target systemctl enable serial-getty@ttyS0.service ;
+                                in-target chown -R {{ user.login }}:{{ user.login }} /home/{{ user.login }}/.ssh; \
+                                in-target /bin/sed -i "s/XKBMODEL=\"[a-z]*\"/XKBMODEL=\"pc105\"/g" /etc/default/keyboard; \
+                                in-target /bin/sed -i "s/XKBLAYOUT=\"[a-z]*\"/XKBLAYOUT=\"de\"/g" /etc/default/keyboard; \
+                                in-target /bin/sed -i "s/XKBVARIANT=\"[a-z]*\"/XKBVARIANT=\"nodeadkeys\"/g" /etc/default/keyboard; \
+                                in-target /bin/sed -i "s/XKBOPTIONS=\"[a-z]*\"/XKBOPTIONS=\"\"/g" /etc/default/keyboard; \
+                                in-target /usr/sbin/dpkg-reconfigure -fnoninteractive keyboard-configuration; \
+                                in-target /usr/sbin/update-locale LC_TIME=en_US.UTF-8 LC_MESSAGES=POSIX
 ubiquity ubiquity/summary note

--- a/host/scripts/wakenuc
+++ b/host/scripts/wakenuc
@@ -19,14 +19,14 @@ NUC_INDEX=$1
 
 # get Intel NUC info (MAC and IP address) from /etc/bootptab (if it exists)
 if [[ -f /etc/bootptab ]]; then
-  NUC_INFO=$(egrep "^mintnuc$NUC_INDEX" /etc/bootptab)
+  NUC_INFO=$(egrep "^nuc$NUC_INDEX" /etc/bootptab)
 
   if [[ ! -z "$NUC_INFO" ]]; then
     NUC_MAC=$(echo $NUC_INFO | awk '{print $3}')
     NUC_IP=$(echo $NUC_INFO | awk '{print $4}')
 
     if [[ -z "$NUC_MAC" || -z "$NUC_IP" ]]; then
-      echo "Can't determine MAC and/or IP address of Intel NUC mintnuc$NUC_INDEX. Aborting."
+      echo "Can't determine MAC and/or IP address of Intel NUC nuc$NUC_INDEX. Aborting."
       exit 1
     else
 
@@ -38,12 +38,12 @@ if [[ -f /etc/bootptab ]]; then
         wakenuc $NUC_MAC
         exit $?
       else
-        echo "Intel NUC mintnuc$NUC_INDEX is already online. Exiting."
+        echo "Intel NUC nuc$NUC_INDEX is already online. Exiting."
         exit 0
       fi
     fi
   else
-    echo "Intel NUC mintnuc$NUC_INDEX not found in /etc/bootptab. Aborting."
+    echo "Intel NUC nuc$NUC_INDEX not found in /etc/bootptab. Aborting."
     exit 1
   fi
 else


### PR DESCRIPTION
…figuration

This PR adds explicit mention of 'Legacy' PXE mode for the preseeded network Ubuntu installation. Also, the hostnames of the Intel NUCs have changed to indicate moving away from Linux Mint-based setups.