### PR TITLE
Put xrdp provisioning behind distribution type gate

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -29,6 +29,7 @@
         - curl
         - ebtables
         - git
+        - net-tools
         - nmap
         - wget
         - zsh
@@ -291,6 +292,7 @@
         append: yes
         state: present
   become: yes
+  when: ansible_distribution == 'Linux Mint'
 
 # named provisioning block - upgrade distribution
 # run as 'root' via ansible's 'become' directive


### PR DESCRIPTION
The PR enables xrdp provisioning for Linux Mint only.